### PR TITLE
Some additional configuration and typing additions/fixes

### DIFF
--- a/cdk/settings.py
+++ b/cdk/settings.py
@@ -1,6 +1,7 @@
 import os
 from typing import Any, Literal
 
+from pydantic import model_validator
 from pydantic_settings import BaseSettings
 
 print("STAGE from env:", os.getenv("STAGE"))
@@ -18,17 +19,39 @@ class StackSettings(BaseSettings):
     STACK_NAME: str = "virtualizarr-data-pipelines"
     STAGE: Literal["dev", "prod"]
     ACCOUNT_ID: str
-    ACCOUNT_REGION: str = "us-east-1"
+    ACCOUNT_REGION: str = "us-west-2"
     ICECHUNK_BUCKET_NAME: str = "icechunk-outuput"
     ICECHUNK_BUCKET: str | None = None
+    ICECHUNK_PREFIX: str | None = None
     DATA_BUCKET_NAME: str | None = None
     PROJECT: str = "virtualizarr-data-pipelines"
     SNS_TOPIC: str | None = None
     MAX_CONCURRENCY: int = 50
     SQS_BATCH_SIZE: int = 10
+    # SQS -> Lambda batching window (seconds). AWS requires this to be >= 1
+    # when SQS_BATCH_SIZE > 10; with a window the poller waits up to this long
+    # to fill a larger batch before invoking. Harmless for batch sizes <= 10.
+    SQS_MAX_BATCHING_WINDOW: int = 5
+
+    # process_messages Lambda tuning. Raise LAMBDA_TIMEOUT toward 900 (the
+    # Lambda max) to fit larger SQS_BATCH_SIZE values.
+    # If commits are run serially on main, bigger batches (fewer commits)
+    # scale better than more concurrency.
+    LAMBDA_TIMEOUT: int = 300
+    LAMBDA_MEMORY: int = 2048
+    # SQS visibility timeout. Must be >= LAMBDA_TIMEOUT so a record isn't
+    # redelivered while its batch is still being processed.
+    VISIBILITY_TIMEOUT: int = 360
+    # How long (in days) SQS retains messages in the main queue and the DLQ
+    # before they are dropped. AWS allows 1-14 days.
+    SQS_RETENTION_PERIOD_DAYS: int = 14
 
     # Freguency in days to run garbage collection.
     GARBAGE_COLLECTION_FREQUENCY: int | None = None
+    # Age (in hours) of snapshots to expire when running garbage collection.
+    # Snapshots older than `now - GARBAGE_COLLECTION_EXPIRY_HOURS` are garbage
+    # collected.
+    GARBAGE_COLLECTION_EXPIRY_HOURS: int = 3
 
     VPC_ID: str | None = None
     # AWS Batch cluster reference to SSM parameter describing the AMI _or_ the AMI ID
@@ -40,3 +63,30 @@ class StackSettings(BaseSettings):
 
     # Cluster scaling max
     BATCH_MAX_VCPU: int = 10
+
+    @model_validator(mode="after")
+    def _check_visibility_timeout(self) -> "StackSettings":
+        if self.VISIBILITY_TIMEOUT < self.LAMBDA_TIMEOUT:
+            raise ValueError(
+                f"VISIBILITY_TIMEOUT ({self.VISIBILITY_TIMEOUT}s) must be >= "
+                f"LAMBDA_TIMEOUT ({self.LAMBDA_TIMEOUT}s)"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _check_retention_period(self) -> "StackSettings":
+        if not 1 <= self.SQS_RETENTION_PERIOD_DAYS <= 14:
+            raise ValueError(
+                f"SQS_RETENTION_PERIOD_DAYS ({self.SQS_RETENTION_PERIOD_DAYS}) must be "
+                f"between 1 and 14 days (AWS SQS limit)"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _check_batching_window(self) -> "StackSettings":
+        if self.SQS_BATCH_SIZE > 10 and self.SQS_MAX_BATCHING_WINDOW < 1:
+            raise ValueError(
+                f"SQS_MAX_BATCHING_WINDOW ({self.SQS_MAX_BATCHING_WINDOW}s) must be "
+                f">= 1 when SQS_BATCH_SIZE ({self.SQS_BATCH_SIZE}) > 10"
+            )
+        return self

--- a/cdk/stack.py
+++ b/cdk/stack.py
@@ -42,7 +42,7 @@ from aws_cdk import (
 from aws_cdk import custom_resources as cr
 from constructs import Construct
 from settings import StackSettings  # type: ignore[import-not-found]
-from stack_constructs import BatchInfra, BatchJob
+from stack_constructs import BatchInfra, BatchJob  # type: ignore[import-not-found]
 
 
 class VirtualizarrSqsStack(Stack):
@@ -61,14 +61,15 @@ class VirtualizarrSqsStack(Stack):
             self,
             f"{settings.STACK_NAME}-Dlq",
             queue_name=f"{settings.STACK_NAME}-Dlq",
-            retention_period=Duration.days(14),
+            retention_period=Duration.days(settings.SQS_RETENTION_PERIOD_DAYS),
         )
 
         self.queue = sqs.Queue(
             self,
             f"{settings.STACK_NAME}-queue",
             queue_name=f"{settings.STACK_NAME}-queue",
-            visibility_timeout=Duration.seconds(1800),
+            visibility_timeout=Duration.seconds(settings.VISIBILITY_TIMEOUT),
+            retention_period=Duration.days(settings.SQS_RETENTION_PERIOD_DAYS),
             dead_letter_queue=sqs.DeadLetterQueue(
                 max_receive_count=20,
                 queue=self.dlq,
@@ -110,8 +111,12 @@ class VirtualizarrSqsStack(Stack):
                 platform=ecr_assets.Platform.LINUX_AMD64,  # or LINUX_AMD64
             ),
             architecture=_lambda.Architecture.X86_64,
-            timeout=Duration.minutes(5),
-            memory_size=2048,
+            timeout=Duration.seconds(settings.LAMBDA_TIMEOUT),
+            memory_size=settings.LAMBDA_MEMORY,
+            environment={
+                "ICECHUNK_BUCKET": self.icechunk_bucket.bucket_name,
+                "ICECHUNK_PREFIX": settings.ICECHUNK_PREFIX or "",
+            },
         )
 
         self.queue.grant_consume_messages(self.process_messages_lambda)
@@ -136,6 +141,7 @@ class VirtualizarrSqsStack(Stack):
             lambda_event_sources.SqsEventSource(
                 self.queue,
                 batch_size=settings.SQS_BATCH_SIZE,
+                max_batching_window=Duration.seconds(settings.SQS_MAX_BATCHING_WINDOW),
                 report_batch_item_failures=True,
                 max_concurrency=settings.MAX_CONCURRENCY,
             )
@@ -152,6 +158,10 @@ class VirtualizarrSqsStack(Stack):
             architecture=_lambda.Architecture.X86_64,
             timeout=Duration.minutes(5),
             memory_size=2048,
+            environment={
+                "ICECHUNK_BUCKET": self.icechunk_bucket.bucket_name,
+                "ICECHUNK_PREFIX": settings.ICECHUNK_PREFIX or "",
+            },
         )
 
         self.icechunk_bucket.grant_read_write(self.initialize_icechunk_lambda)
@@ -170,8 +180,13 @@ class VirtualizarrSqsStack(Stack):
                     },
                     physical_resource_id=cr.PhysicalResourceId.of("trigger-once-id"),
                 ),
-                policy=cr.AwsCustomResourcePolicy.from_sdk_calls(
-                    resources=[self.initialize_icechunk_lambda.function_arn]
+                policy=cr.AwsCustomResourcePolicy.from_statements(
+                    [
+                        iam.PolicyStatement(
+                            actions=["lambda:InvokeFunction"],
+                            resources=[self.initialize_icechunk_lambda.function_arn],
+                        )
+                    ]
                 ),
             )
 
@@ -222,6 +237,11 @@ class VirtualizarrSqsStack(Stack):
                 image_asset=self.gc_image_asset,
                 memory_mb=2000,
                 retry_attempts=1,
+                environment={
+                    "GARBAGE_COLLECTION_EXPIRY_HOURS": str(
+                        settings.GARBAGE_COLLECTION_EXPIRY_HOURS
+                    ),
+                },
             )
             self.icechunk_bucket.grant_read_write(self.gc_job.role)
 

--- a/lambda/garbage_collect/handler.py
+++ b/lambda/garbage_collect/handler.py
@@ -1,3 +1,4 @@
+import os
 from datetime import datetime, timedelta, timezone
 
 from aws_lambda_powertools import Logger
@@ -9,9 +10,11 @@ logger = Logger()
 def handler() -> None:
     try:
         virtualizarr_processor = Processor()
-        expiry_time = datetime.now(timezone.utc) - timedelta(days=2)
-        print(expiry_time)
-        virtualizarr_processor.garbage_collect(expiry_time=expiry_time)
+        expiry_hours = int(os.getenv("GARBAGE_COLLECTION_EXPIRY_HOURS", "3"))
+        expiry_time = datetime.now(timezone.utc) - timedelta(hours=expiry_hours)
+        logger.info(f"Garbage collecting snapshots older than {expiry_time}")
+        repo = virtualizarr_processor.initialize_repo()
+        virtualizarr_processor.garbage_collect(expiry_time=expiry_time, repo=repo)
         logger.info("Icechunk garbage collected")
     except Exception as e:
         logger.error(f"Error in custom resource handler: {e}")

--- a/lambda/process_messages/handler.py
+++ b/lambda/process_messages/handler.py
@@ -1,4 +1,5 @@
 import json
+import os
 from typing import Any, Dict
 
 from aws_lambda_powertools import Logger, Tracer
@@ -35,7 +36,7 @@ def process_notification(
     if key and bucket:
         s3_uri = f"s3://{bucket}/{key}"
         logger.info(
-            "Append file",
+            "Processing file",
             extra={"bucket": bucket, "key": key, "s3_uri": s3_uri},
         )
         processor.process_file(file_key=key, session=session)
@@ -55,7 +56,9 @@ def handler(event: Any, context: LambdaContext) -> PartialItemFailureResponse:
     """
     sqs_event = SQSEvent(event)
     records = sqs_event.raw_event["Records"]
-    virtualizarr_processor = Processor()
+    bucket = os.getenv("ICECHUNK_BUCKET", "")
+    prefix = os.getenv("ICECHUNK_PREFIX", "")
+    virtualizarr_processor = Processor(bucket=bucket, prefix=prefix)
     repo = virtualizarr_processor.initialize_repo()
     session = virtualizarr_processor.initialize_session(repo=repo)
 
@@ -104,8 +107,8 @@ def handler(event: Any, context: LambdaContext) -> PartialItemFailureResponse:
     try:
         snapshot_id = virtualizarr_processor.commit_processed_files(session=session)
         logger.info(f"Committed to {snapshot_id}")
-    except Exception:
-        logger.error("Commit failed, marking all records as failed")
+    except Exception as e:
+        logger.error(f"Commit failed with error: {e}. Marking all records as failed")
         return {
             "batchItemFailures": [
                 {"itemIdentifier": record["messageId"]} for record in records

--- a/lambda/virtualizarr-processor/virtualizarr_processor/processor.py
+++ b/lambda/virtualizarr-processor/virtualizarr_processor/processor.py
@@ -63,6 +63,10 @@ def synthetic_vds(date: str) -> xr.Dataset:
 
 
 class Processor:
+    def __init__(self, bucket: str = "", prefix: str = "") -> None:
+        self.bucket = bucket
+        self.prefix = prefix
+
     def initialize_repo(self) -> Repository:
         chunk_store = icechunk.local_filesystem_store(CHUNK_DIR)
         storage = icechunk.in_memory_storage()
@@ -104,8 +108,9 @@ class Processor:
         snapshot = session.commit(message=f"Append to {session.snapshot_id}")
         return str(snapshot)
 
-    def garbage_collect(self, expiry_time: datetime) -> icechunk.GCSummary:
-        repo = self.initialize_repo()
+    def garbage_collect(
+        self, repo: Repository, expiry_time: datetime
+    ) -> icechunk.GCSummary:
         repo.expire_snapshots(older_than=expiry_time)
         gcs = repo.garbage_collect(delete_object_older_than=expiry_time)
         return gcs

--- a/lambda/virtualizarr-processor/virtualizarr_processor/typing.py
+++ b/lambda/virtualizarr-processor/virtualizarr_processor/typing.py
@@ -70,7 +70,7 @@ class VirtualizarrProcessor(Protocol):
         """
         ...
 
-    def garbage_collect(self, expiry_time: datetime) -> icechunk.GCSummary:
+    def garbage_collect(self, repo: Repository, expiry_time: datetime) -> icechunk.GCSummary:
         """
         Run Icechunk garbage collection and snapshot removal.
 

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -35,6 +35,7 @@ def test_commit_processed_files(icechunk_session: Session) -> None:
 
 def test_garbage_collect() -> None:
     processor = Processor()
+    repo = processor.initialize_repo()
     expiry_time = datetime.now(timezone.utc) - timedelta(days=2)
-    gcs = processor.garbage_collect(expiry_time=expiry_time)
+    gcs = processor.garbage_collect(repo=repo, expiry_time=expiry_time)
     assert isinstance(gcs, icechunk.GCSummary)


### PR DESCRIPTION
This PR adds some additional AWS configuration parameters.

A few other object modeling changes:
* Passes a `repo` parameter into processor.garbage_collect (repo seems like a necessary argument to garbage collect, unless we add `repo` as an attribute of `Processor`)
* Adds an `__init__` function in the example processor module. This is not a necessity, given the example is still valid without it, but seems like an almost universal pattern to instantiate the processor with a bucket and prefix that it will store the icechunk repo in. I debated whether to keep this in but thought it useful enough to keep/